### PR TITLE
remove ssh dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,5 @@ tags
 
 
 # End of https://www.gitignore.io/api/python,sublimetext,vim,emacs,git,pycharm,macos,visualstudiocode
+
+.idea/

--- a/temple/ls.py
+++ b/temple/ls.py
@@ -42,7 +42,7 @@ def _code_search(query, github_user=None):
     Raises:
         `InvalidGithubUserError`: When ``github_user`` is invalid
     """
-    github_client = temple.utils.GithubClient()
+    github_client = temple.utils.get_git_client()
     headers = {'Accept': 'application/vnd.github.v3.text-match+json'}
 
     resp = github_client.get('/search/code',
@@ -105,7 +105,6 @@ def ls(github_user, template=None):
     temple.check.has_env_vars(temple.constants.GITHUB_API_TOKEN_ENV_VAR)
 
     if template:
-        temple.check.is_git_ssh_path(template)
         template_repo_name = temple.check.get_name_from_ssh_path(template)
         search_q = 'user:{} filename:{} {}'.format(
             github_user,

--- a/temple/setup.py
+++ b/temple/setup.py
@@ -57,7 +57,6 @@ def setup(template, version=None):
         version (str, optional): The version of the template to use when updating. Defaults
             to the latest version
     """
-    temple.check.is_git_ssh_path(template)
     temple.check.not_in_git_repo()
 
     repo_path = temple.utils.get_repo_path(template)

--- a/temple/tests/test_update.py
+++ b/temple/tests/test_update.py
@@ -8,6 +8,8 @@ import requests
 import temple.constants
 import temple.update
 
+import cookiecutter.vcs
+
 
 @pytest.mark.parametrize(
     'old_config, new_config, old_http_status, new_http_status, expected_has_changed',
@@ -93,9 +95,9 @@ def test_get_latest_template_version_w_git_ssh(mocker, stdout, stderr, expected)
         marks=pytest.mark.xfail(raises=temple.exceptions.CheckRunError)),
 ])
 def test_get_latest_template_version(mocker, git_ssh_side_effect, git_api_side_effect, expected):
-    mocker.patch('temple.update._get_latest_template_version_w_git_ssh',
+    mocker.patch('temple.update._get_latest_template_version_w_git',
                  autospec=True, side_effect=git_ssh_side_effect)
-    mocker.patch('temple.update._get_latest_template_version_w_git_api',
+    mocker.patch('temple.update._get_latest_template_version_w_github',
                  autospec=True, side_effect=git_api_side_effect)
 
     version = temple.update._get_latest_template_version('template')

--- a/temple/tests/test_update.py
+++ b/temple/tests/test_update.py
@@ -54,7 +54,7 @@ def test_get_latest_template_version_w_git_api(http_status, mocker, responses):
     api = 'https://api.github.com/repos/owner/template/commits'
     responses.add(responses.GET, api, json=[{'sha': 'v1'}], status=http_status)
 
-    latest = temple.update._get_latest_template_version_w_git_api(
+    latest = temple.update._get_latest_template_version_w_github(
         'git@github.com:owner/template.git')
     assert latest == 'v1'
 
@@ -73,7 +73,7 @@ def test_get_latest_template_version_w_git_ssh(mocker, stdout, stderr, expected)
                               autospec=True,
                               return_value=ls_remote_return)
 
-    assert temple.update._get_latest_template_version_w_git_ssh('t') == expected
+    assert temple.update._get_latest_template_version_w_git('t') == expected
     cmd = 'git ls-remote t | grep HEAD | cut -f1'
     mock_shell.assert_called_once_with(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 

--- a/temple/tests/test_update.py
+++ b/temple/tests/test_update.py
@@ -10,38 +10,27 @@ import temple.update
 
 
 @pytest.mark.parametrize(
-    'old_config, new_config, old_http_status, new_http_status, expected_has_changed',
+    'old_config, new_config, expected_has_changed',
     [
-        ('{"config": "same"}', '{"config": "same"}', http_codes.ok, http_codes.ok, False),
-        ('{"config": "same"}', '{"config": "diff"}', http_codes.ok, http_codes.ok, True),
-        pytest.param('', '', http_codes.not_found, http_codes.ok, None,
-                     marks=pytest.mark.xfail(raises=requests.exceptions.HTTPError)),
-        pytest.param('', '', http_codes.ok, http_codes.not_found, None,
-                     marks=pytest.mark.xfail(raises=requests.exceptions.HTTPError)),
+        ('{"config": "same"}', '{"config": "same"}', False),
+        ('{"config": "same"}', '{"config": "diff"}', True),
     ])
 def test_cookiecutter_configs_have_changed(old_config,
                                            new_config,
-                                           old_http_status,
-                                           new_http_status,
                                            expected_has_changed,
                                            mocker,
                                            responses):
     """Tests temple.update._cookiecutter_configs_have_changed"""
-    api = 'https://api.github.com/repos/org/template/contents/cookiecutter.json'
-    responses.add(responses.GET,
-                  '{}?ref=old'.format(api),
-                  json={'content': old_config},
-                  status=old_http_status,
-                  match_querystring=True)
-    responses.add(responses.GET,
-                  '{}?ref=new'.format(api),
-                  json={'content': new_config},
-                  status=new_http_status,
-                  match_querystring=True)
-
+    mock_clone = mocker.patch('temple.update.cc_vcs.clone', autospec=True, return_value='path')
+    mock_open = mocker.patch('temple.update.open')
+    mock_open().read.side_effect = [old_config, new_config]
+    mock_call = mocker.patch('subprocess.check_call', autospec=True)
     template = 'git@github.com:org/template.git'
+
     config_has_changed = temple.update._cookiecutter_configs_have_changed(template, 'old', 'new')
     assert config_has_changed == expected_has_changed
+    mock_clone.assert_called_once_with(template, 'old', mocker.ANY)
+    assert mock_call.call_count == 1
 
 
 @pytest.mark.parametrize('http_status', [
@@ -49,7 +38,7 @@ def test_cookiecutter_configs_have_changed(old_config,
     pytest.param(http_codes.not_found,
                  marks=pytest.mark.xfail(raises=requests.exceptions.HTTPError)),
 ])
-def test_get_latest_template_version_w_git_api(http_status, mocker, responses):
+def test_get_latest_template_version_w_github(http_status, mocker, responses):
     """Tests temple.update._get_latest_template_version_w_git_api"""
     api = 'https://api.github.com/repos/owner/template/commits'
     responses.add(responses.GET, api, json=[{'sha': 'v1'}], status=http_status)
@@ -65,7 +54,7 @@ def test_get_latest_template_version_w_git_api(http_status, mocker, responses):
     pytest.param(b'\n', b'stderr_w_no_stdout_is_an_error', None,
                  marks=pytest.mark.xfail(raises=RuntimeError)),
 ])
-def test_get_latest_template_version_w_git_ssh(mocker, stdout, stderr, expected):
+def test_get_latest_template_version_w_git(mocker, stdout, stderr, expected):
     """Tests temple.update._get_latest_template_version_w_git_ssh"""
     ls_remote_return = subprocess.CompletedProcess([], returncode=0, stdout=stdout,
                                                    stderr=stderr)

--- a/temple/tests/test_update.py
+++ b/temple/tests/test_update.py
@@ -8,8 +8,6 @@ import requests
 import temple.constants
 import temple.update
 
-import cookiecutter.vcs
-
 
 @pytest.mark.parametrize(
     'old_config, new_config, old_http_status, new_http_status, expected_has_changed',

--- a/temple/update.py
+++ b/temple/update.py
@@ -34,14 +34,15 @@ def _cookiecutter_configs_have_changed(template, old_version, new_version):
     Returns:
         bool: True if the cookiecutter.json files have been changed in the old and new versions
     """
-    with tempfile.TemporaryDirectory() as clone_dir:
-        repo_dir = cc_vcs.clone(template, old_version, clone_dir)
-        old_config = json.load(open(os.path.join(repo_dir, 'cookiecutter.json')))
-        subprocess.check_call(f'git checkout {new_version}', cwd=repo_dir, shell=True, stderr=subprocess.PIPE)
-        new_config = json.load(open(os.path.join(repo_dir, 'cookiecutter.json')))
+    repo_path = temple.utils.get_repo_path(template)
+    github_client = temple.utils.get_git_client(template)
+    api = '/repos/{}/contents/cookiecutter.json'.format(repo_path)
+    old_config_resp = github_client.get(api, params={'ref': old_version})
+    old_config_resp.raise_for_status()
+    new_config_resp = github_client.get(api, params={'ref': new_version})
+    new_config_resp.raise_for_status()
 
-    return old_config != new_config
-
+    return old_config_resp.json()['content'] != new_config_resp.json()['content']
 
 def _get_latest_template_version_w_git(template):
     """
@@ -64,7 +65,7 @@ def _get_latest_template_version_w_github(template):
 
     repo_path = temple.utils.get_repo_path(template)
     api = '/repos/{}/commits'.format(repo_path)
-    github_client = temple.utils.GithubClient()
+    github_client = temple.utils.get_git_client(template)
 
     last_commit_resp = github_client.get(api, params={'per_page': 1})
     last_commit_resp.raise_for_status()

--- a/temple/utils.py
+++ b/temple/utils.py
@@ -132,13 +132,12 @@ class GitLabClient():
         api_token = os.environ.get('GITLAB_API_TOKEN')
         gitlab_api = 'https://gitlab.com/api/v4'
         self.headers = { 'Authorization': f"Bearer {api_token}" }
-        query = template.split('/')[-1:]
+        query = template.split('/')[-1:][0]
         url = f"{gitlab_api}/projects?search={query}"
         search_response = requests.get(url, headers=self.headers)
         search_result = search_response.json()
         if len(search_result) != 1:
-            print('Template search inconclusive.')
-            exit()
+            raise ValueError('Template search inconclusive.')
         self.file_api = f"{gitlab_api}/projects/{search_result[0]['id']}/repository/files"
 
     def get(self, void, **request_kwargs):

--- a/temple/utils.py
+++ b/temple/utils.py
@@ -55,6 +55,29 @@ def write_temple_config(temple_config, template, version):
         yaml.dump(versioned_config, temple_config_file, Dumper=yaml.SafeDumper)
 
 
+def get_cookiecutter_repo(template, version=None):
+    """Obtains the repo and default configuration
+
+    Args:
+        template: Path to the template
+        default_config (dict, optional): The default configuration
+        version (str, optional): The git SHA or branch to use when
+            checking out template. Defaults to latest version
+
+    Returns:
+        tuple: The cookiecutter repo directory and the config dict
+    """
+    config_dict = cc_config.get_user_config()
+    repo_dir, _ = cc_repository.determine_repo_dir(
+        template=template,
+        abbreviations=config_dict['abbreviations'],
+        clone_to_dir=config_dict['cookiecutters_dir'],
+        checkout=version,
+        no_input=True)
+    context_file = os.path.join(repo_dir, 'cookiecutter.json')
+    return repo_dir, context_file
+
+
 def get_cookiecutter_config(template, default_config=None, version=None):
     """Obtains the configuration used for cookiecutter templating
 
@@ -67,15 +90,9 @@ def get_cookiecutter_config(template, default_config=None, version=None):
     Returns:
         tuple: The cookiecutter repo directory and the config dict
     """
-    default_config = default_config or {}
     config_dict = cc_config.get_user_config()
-    repo_dir, _ = cc_repository.determine_repo_dir(
-        template=template,
-        abbreviations=config_dict['abbreviations'],
-        clone_to_dir=config_dict['cookiecutters_dir'],
-        checkout=version,
-        no_input=True)
-    context_file = os.path.join(repo_dir, 'cookiecutter.json')
+    default_config = default_config or {}
+    repo_dir, context_file = get_cookiecutter_repo(template, version)
     context = cc_generate.generate_context(
         context_file=context_file,
         default_context={**config_dict['default_context'], **default_config})

--- a/temple/utils.py
+++ b/temple/utils.py
@@ -55,29 +55,6 @@ def write_temple_config(temple_config, template, version):
         yaml.dump(versioned_config, temple_config_file, Dumper=yaml.SafeDumper)
 
 
-def get_cookiecutter_repo(template, version=None):
-    """Obtains the repo and default configuration
-
-    Args:
-        template: Path to the template
-        default_config (dict, optional): The default configuration
-        version (str, optional): The git SHA or branch to use when
-            checking out template. Defaults to latest version
-
-    Returns:
-        tuple: The cookiecutter repo directory and the config dict
-    """
-    config_dict = cc_config.get_user_config()
-    repo_dir, _ = cc_repository.determine_repo_dir(
-        template=template,
-        abbreviations=config_dict['abbreviations'],
-        clone_to_dir=config_dict['cookiecutters_dir'],
-        checkout=version,
-        no_input=True)
-    context_file = os.path.join(repo_dir, 'cookiecutter.json')
-    return repo_dir, context_file
-
-
 def get_cookiecutter_config(template, default_config=None, version=None):
     """Obtains the configuration used for cookiecutter templating
 
@@ -90,9 +67,15 @@ def get_cookiecutter_config(template, default_config=None, version=None):
     Returns:
         tuple: The cookiecutter repo directory and the config dict
     """
-    config_dict = cc_config.get_user_config()
     default_config = default_config or {}
-    repo_dir, context_file = get_cookiecutter_repo(template, version)
+    config_dict = cc_config.get_user_config()
+    repo_dir, _ = cc_repository.determine_repo_dir(
+        template=template,
+        abbreviations=config_dict['abbreviations'],
+        clone_to_dir=config_dict['cookiecutters_dir'],
+        checkout=version,
+        no_input=True)
+    context_file = os.path.join(repo_dir, 'cookiecutter.json')
     context = cc_generate.generate_context(
         context_file=context_file,
         default_context={**config_dict['default_context'], **default_config})


### PR DESCRIPTION
Makes it so `temple setup` and `temple update` work with `https://` git repositories as well as SSH `git@`.